### PR TITLE
Fixing bug that can happen if files created too close together

### DIFF
--- a/motion/checkLastCapture
+++ b/motion/checkLastCapture
@@ -12,7 +12,7 @@ CAPDIR=$1
 CAPFILE=$(ls -t $CAPDIR | head -1)
 if [ -n "$CAPFILE" ]; then
     CAPTIME=`date -r "$CAPDIR/$CAPFILE"`
-    echo "Last motion was captured at $CAPTIME"
+    echo "Last motion was $CAPDIR/$CAPFILE captured at $CAPTIME"
 
     # Remove all other captures, assumes filenames have no newlines
     ls -dt $CAPDIR/* | tail -n +2 | xargs --null -r -d "\n" rm

--- a/motion/checkLastCapture
+++ b/motion/checkLastCapture
@@ -9,13 +9,14 @@ fi
 CAPDIR=$1
 
 # Get last capture
-CAPFILE=$(ls -t $CAPDIR | head -1)
+# NOTE: Assumes filenames are in motion command's default format, e.g. 01-20150621183214-02.jpg
+CAPFILE=$(ls $CAPDIR | tail -1)
 if [ -n "$CAPFILE" ]; then
     CAPTIME=`date -r "$CAPDIR/$CAPFILE"`
     echo "Last motion was $CAPDIR/$CAPFILE captured at $CAPTIME"
 
-    # Remove all other captures, assumes filenames have no newlines
-    ls -dt $CAPDIR/* | tail -n +2 | xargs --null -r -d "\n" rm
+    # Remove all other captures
+    ls -d $CAPDIR/* | head -n -1 | xargs --null -r -d "\n" rm
 else
     echo "No captures found in $CAPDIR"
 fi

--- a/motion/motion.conf
+++ b/motion/motion.conf
@@ -1,5 +1,4 @@
 framerate 3
 gap 3
-on_event_start ./eventStarted
 target_dir captures
 threshold 10000

--- a/motion/test/testCheckLastCapture.py
+++ b/motion/test/testCheckLastCapture.py
@@ -2,7 +2,6 @@ import unittest
 from subprocess import check_output, CalledProcessError
 import os
 import shutil
-import time
 
 SCRIPT_CMD = "../checkLastCapture"
 CAPTURES_DIR = "testCaptures"
@@ -46,39 +45,37 @@ class TestCheckLastCapture(unittest.TestCase):
         self.assertEqual(output, "No captures found in " + CAPTURES_DIR + "\n");
 
     def test_one_file(self):
-        path, modified = openFileAndGetModifiedTime("test")
+        path, modified = openFileAndGetModifiedTime("01-20150621183214-02.jpg")
         output = check_output([SCRIPT_CMD, CAPTURES_DIR])
 
         self.assertEqual(output, "Last motion was " + path + " captured at " + modified)
 
         captures = os.listdir(CAPTURES_DIR)
         self.assertEqual(len(captures), 1)
-        self.assertEqual(captures[0], "test");
+        self.assertEqual(captures[0], "01-20150621183214-02.jpg");
 
     def test_multiple_files(self):
-        path, modified = openFileAndGetModifiedTime("test")
-        time.sleep(1); # Otherwise the last modified times are too close together
-        path2, modified2 = openFileAndGetModifiedTime("test2")
+        path, modified = openFileAndGetModifiedTime("01-20150621183214-02.jpg")
+        path2, modified2 = openFileAndGetModifiedTime("01-20150621183215-00.jpg")
         output = check_output([SCRIPT_CMD, CAPTURES_DIR])
 
         self.assertEqual(output, "Last motion was " + path2 + " captured at " + modified2)
 
         captures = os.listdir(CAPTURES_DIR)
         self.assertEqual(len(captures), 1)
-        self.assertEqual(captures[0], "test2");
+        self.assertEqual(captures[0], "01-20150621183215-00.jpg");
 
     def test_run_twice(self):
-        path, modified = openFileAndGetModifiedTime("test")
+        path, modified = openFileAndGetModifiedTime("01-20150621183214-02.jpg")
         output = check_output([SCRIPT_CMD, CAPTURES_DIR])
-        time.sleep(1); # Otherwise the last modified times are too close together
-        path2, modified2 = openFileAndGetModifiedTime("test2")
+        path2, modified2 = openFileAndGetModifiedTime("01-20150621183215-00.jpg")
         output = check_output([SCRIPT_CMD, CAPTURES_DIR])
 
         self.assertEqual(output, "Last motion was " + path2 + " captured at " + modified2)
 
         captures = os.listdir(CAPTURES_DIR)
         self.assertEqual(len(captures), 1)
-        self.assertEqual(captures[0], "test2");
+        self.assertEqual(captures[0], "01-20150621183215-00.jpg");
 
 if __name__ == '__main__':
     unittest.main()

--- a/motion/test/testCheckLastCapture.py
+++ b/motion/test/testCheckLastCapture.py
@@ -2,9 +2,16 @@ import unittest
 from subprocess import check_output, CalledProcessError
 import os
 import shutil
+import time
 
 SCRIPT_CMD = "../checkLastCapture"
 CAPTURES_DIR = "testCaptures"
+
+def openFileAndGetModifiedTime(name):
+    testFilePath = os.path.join(CAPTURES_DIR, name)
+    testFile = open(testFilePath, "w")
+    modifiedTime = check_output(["date", "-r", testFilePath])
+    return testFilePath, modifiedTime
 
 class TestCheckLastCapture(unittest.TestCase):
 
@@ -35,7 +42,43 @@ class TestCheckLastCapture(unittest.TestCase):
 
     def test_no_files(self):
         output = check_output([SCRIPT_CMD, CAPTURES_DIR])
+
         self.assertEqual(output, "No captures found in " + CAPTURES_DIR + "\n");
+
+    def test_one_file(self):
+        path, modified = openFileAndGetModifiedTime("test")
+        output = check_output([SCRIPT_CMD, CAPTURES_DIR])
+
+        self.assertEqual(output, "Last motion was " + path + " captured at " + modified)
+
+        captures = os.listdir(CAPTURES_DIR)
+        self.assertEqual(len(captures), 1)
+        self.assertEqual(captures[0], "test");
+
+    def test_multiple_files(self):
+        path, modified = openFileAndGetModifiedTime("test")
+        time.sleep(1); # Otherwise the last modified times are too close together
+        path2, modified2 = openFileAndGetModifiedTime("test2")
+        output = check_output([SCRIPT_CMD, CAPTURES_DIR])
+
+        self.assertEqual(output, "Last motion was " + path2 + " captured at " + modified2)
+
+        captures = os.listdir(CAPTURES_DIR)
+        self.assertEqual(len(captures), 1)
+        self.assertEqual(captures[0], "test2");
+
+    def test_run_twice(self):
+        path, modified = openFileAndGetModifiedTime("test")
+        output = check_output([SCRIPT_CMD, CAPTURES_DIR])
+        time.sleep(1); # Otherwise the last modified times are too close together
+        path2, modified2 = openFileAndGetModifiedTime("test2")
+        output = check_output([SCRIPT_CMD, CAPTURES_DIR])
+
+        self.assertEqual(output, "Last motion was " + path2 + " captured at " + modified2)
+
+        captures = os.listdir(CAPTURES_DIR)
+        self.assertEqual(len(captures), 1)
+        self.assertEqual(captures[0], "test2");
 
 if __name__ == '__main__':
     unittest.main()

--- a/planning/Ping Pong Pi.mm
+++ b/planning/Ping Pong Pi.mm
@@ -155,6 +155,20 @@
 <node CREATED="1433645443591" ID="ID_412616605" MODIFIED="1433645444910" TEXT="Solution">
 <node CREATED="1433645445596" ID="ID_1409640841" MODIFIED="1433645454305" TEXT="Get latest capture from captures dir"/>
 </node>
+<node CREATED="1434937683269" ID="ID_528108938" MODIFIED="1434937684261" TEXT="Problem">
+<node CREATED="1434937685195" ID="ID_444145060" MODIFIED="1434939225748" TEXT="If the file creates are too close together, ls doesn&apos;t always return the correct one (resolution isn&apos;t small enough)">
+<icon BUILTIN="button_ok"/>
+</node>
+<node CREATED="1434937705841" ID="ID_865193749" MODIFIED="1434939225748" TEXT="If we rely on the filename, that creates a tight dependency, no?">
+<icon BUILTIN="button_ok"/>
+<node CREATED="1434939215295" ID="ID_1965479041" MODIFIED="1434939219119" TEXT="Meh, used it. Fixed now"/>
+</node>
+<node CREATED="1434937905651" ID="ID_235970445" MODIFIED="1434937933169" TEXT="We can always transform the timestamp when we pass across to the website"/>
+<node CREATED="1434938101584" ID="ID_1642271525" MODIFIED="1434938108616" TEXT="Also, do we need to reintroduce locking?">
+<node CREATED="1434938437211" ID="ID_604657359" MODIFIED="1434938448026" TEXT="What if something hangs, or just takes a little longer than usual?"/>
+</node>
+<node CREATED="1434938457828" ID="ID_1656352208" MODIFIED="1434938479260" TEXT="What if another file gets added while we&apos;re processing? We might delete that..."/>
+</node>
 </node>
 <node CREATED="1431301460459" ID="ID_1634956536" MODIFIED="1431301461589" POSITION="right" TEXT="the site"/>
 </node>


### PR DESCRIPTION
If 2 files are created very close together, ls might not sort them by last modified date perfectly. So instead we're relying on the filenames generated by the motion command which will be created in ascending alphabetical order.
